### PR TITLE
Do not use __int128 if __STRICT_ANSI__ is defined

### DIFF
--- a/Fixed.h
+++ b/Fixed.h
@@ -52,7 +52,7 @@ struct type_from_size {
 	typedef void      value_type;
 };
 
-#if defined(__GNUC__) && defined(__x86_64__)
+#if defined(__GNUC__) && defined(__x86_64__) && !defined(__STRICT_ANSI__)
 template <>
 struct type_from_size<128> {
 	static const bool           is_specialized = true;


### PR DESCRIPTION
This prevents error in case of strict standard compliance is required from the compiler.