### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+addons:
+  apt:
+    sources:
+      - george-edison55-precise-backports
+      - llvm-toolchain-trusty-6.0
+      - ubuntu-toolchain-r-test
+    packages:
+      - clang-6.0
+      - cmake-data
+      - cmake
+      - g++-8
+      - libboost-dev
+
+env:
+ - CC=clang-6.0 CXX=clang++-6.0 STD=14
+ - CC=gcc-8 CXX=g++-8 STD=14
+ - CC=clang-6.0 CXX=clang++-6.0 STD=17
+ - CC=gcc-8 CXX=g++-8 STD=17
+
+script:
+ - cmake -DCMAKE_CXX_STANDARD=$STD .
+ - make
+ - make test
+


### PR DESCRIPTION
Building all utilities using Clang 6 / GCC 8 using C++14 / C++17. You can see an example build [here](https://travis-ci.org/ooxi/cpp-utilities/builds/414853002). I did not include C++11 since [FlatMap](https://github.com/eteran/cpp-utilities/blob/master/container/include/eteran/cpp-utilities/FlatMap.h#L215) seems to require [C++14](https://en.cppreference.com/w/cpp/iterator/rbegin).