### PR TITLE
unintended sign extension in fixed.h

### DIFF
--- a/fixed/include/cpp-utilities/fixed.h
+++ b/fixed/include/cpp-utilities/fixed.h
@@ -444,7 +444,7 @@ public: // conversion to basic types
 	}
 
 	constexpr unsigned int to_uint() const {
-		return (data_ & integer_mask) >> fractional_bits;
+		return static_cast<unsigned int>(data_ & integer_mask) >> fractional_bits;
 	}
 
 	constexpr float to_float() const {

--- a/fixed/test/fixed.cpp
+++ b/fixed/test/fixed.cpp
@@ -59,4 +59,7 @@ int main() {
 	static_assert(0 !=   fixed{1}, "");
 	static_assert(1 >=   fixed{0}, "");
 	static_assert(0.5 <= fixed{1}, "");
+
+	// conversion test
+	assert(fixed(0x8000).to_uint() == 0x8000);
 }


### PR DESCRIPTION
Hi,

I've been using using fixed.h.
I noticed that `to_uint()` method looks to perform unexpected sign extension.

I hope this patch helps you.

Regards.
