### PR TITLE
Explicit test return code

### DIFF
--- a/fixed/test/fixed.cpp
+++ b/fixed/test/fixed.cpp
@@ -1,6 +1,7 @@
 #include <cpp-utilities/fixed.h>
 #include <iostream>
 #include <cassert>
+#include <cstdlib>
 
 using fixed = numeric::fixed<16, 16>;
 
@@ -62,4 +63,6 @@ int main() {
 
 	// conversion test
 	assert(fixed(0x8000).to_uint() == 0x8000);
+
+	return EXIT_SUCCESS;
 }


### PR DESCRIPTION
`main` without explicit return is a valid special case. Would be great if you could merge this change nevertheless since I would like to call this test in my CI and cannot use the `main` special case.